### PR TITLE
fix: Increase max param length

### DIFF
--- a/server.js
+++ b/server.js
@@ -28,6 +28,7 @@ const fastify = Fastify({
   logger: {
     level: logLevel,
   },
+  maxParamLength: 1024,
 });
 await fastify.register(acceptReader);
 await fastify.register(fastifyRateLimit, {});


### PR DESCRIPTION
# Why?
Some URLs do not work with the service.

# What?
Digging into this, I've learned that since https://github.com/imagecdn/imagecdn/commit/7426c5874725e5349ff6b124746af22ea9a75c5b we've had a default param length of 100.
This increases it to 1024 which is well above the previous limit.